### PR TITLE
tests: Update DB disk size

### DIFF
--- a/brightbox/data_source_brightbox_database_type_test.go
+++ b/brightbox/data_source_brightbox_database_type_test.go
@@ -22,7 +22,7 @@ func TestAccBrightboxDatabaseType_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.brightbox_database_type.foobar", "ram", "4096"),
 					resource.TestCheckResourceAttr(
-						"data.brightbox_database_type.foobar", "disk_size", "40960"),
+						"data.brightbox_database_type.foobar", "disk_size", "61440"),
 				),
 			},
 		},


### PR DESCRIPTION
This is to fix the following test failure:

```
=== RUN   TestAccBrightboxDatabaseType_basic
--- FAIL: TestAccBrightboxDatabaseType_basic (5.37s)
    testing.go:538: Step 0 error: Check failed: Check 4/4 error: data.brightbox_database_type.foobar: Attribute 'disk_size' expected "40960", got "61440"
FAIL
```