### PR TITLE
provider: Add req/resp logging to Orbit

### DIFF
--- a/brightbox/resource_brightbox_container.go
+++ b/brightbox/resource_brightbox_container.go
@@ -231,7 +231,6 @@ func createApiClient(
 }
 
 func createContainerUrl(d *schema.ResourceData, name string) (string, error) {
-
 	base_url, err := url.Parse(d.Get("orbit_url").(string))
 	if err != nil {
 		return "", err
@@ -263,19 +262,4 @@ func createContainer(url string, token *string) error {
 
 func destroyContainer(url string, token *string) error {
 	return manipulateContainer(url, token, "DELETE")
-}
-
-func makeHttpRequest(req *http.Request) (resp *http.Response, err error) {
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		if resp != nil {
-			defer resp.Body.Close()
-		}
-		return resp, fmt.Errorf("Error accessing Orbit: %s", err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusPartialContent {
-		defer resp.Body.Close()
-		return resp, fmt.Errorf("HTTP error response %v", resp.Status)
-	}
-	return resp, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/brightbox/gobrightbox v0.2.1
 	github.com/google/go-cmp v0.2.0
+	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/go-getter v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v0.7.0 // indirect
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104 // indirect


### PR DESCRIPTION
This was apparently just missed in https://github.com/terraform-providers/terraform-provider-brightbox/pull/4 

I assume long term _all_ requests should go through the SDK, so we can avoid this kind of confusion?